### PR TITLE
homebridge-ring login ui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ typings/
 .yarn-integrity
 .env
 .next
+.idea
 etc/persist
 etc/accessories
 

--- a/controllers/ring-login.js
+++ b/controllers/ring-login.js
@@ -1,0 +1,59 @@
+/**************************************************************************************************
+ * hoobs-core                                                                                     *
+ * Copyright (C) 2020 HOOBS                                                                       *
+ *                                                                                                *
+ * This program is free software: you can redistribute it and/or modify                           *
+ * it under the terms of the GNU General Public License as published by                           *
+ * the Free Software Foundation, either version 3 of the License, or                              *
+ * (at your option) any later version.                                                            *
+ *                                                                                                *
+ * This program is distributed in the hope that it will be useful,                                *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                                 *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                                  *
+ * GNU General Public License for more details.                                                   *
+ *                                                                                                *
+ * You should have received a copy of the GNU General Public License                              *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.                          *
+ **************************************************************************************************/
+
+const Request = require('axios')
+const HBS = require("../server/instance")
+
+module.exports = class RingLogin {
+  constructor() {
+    HBS.app.post("/api/ring-login", (request, response) => this.attemptLogin(request, response));
+  }
+
+  async attemptLogin (request, response) {
+    const { email, password, verificationCode } = request.body
+
+    try {
+      const tokenResponse = await Request.post('https://oauth.ring.com/oauth/token',
+        {
+          client_id: 'ring_official_android',
+          scope: 'client',
+          grant_type: 'password',
+          password,
+          username: email
+        },
+        {
+          headers: {
+            'content-type': 'application/json',
+            '2fa-support': 'true',
+            '2fa-code': verificationCode || ''
+          }
+        })
+
+      response.send(tokenResponse.data)
+    } catch (e) {
+      if (e.response.data) {
+        // 2fa required or bad credentials
+        response.send(e.response.data)
+      } else {
+        HBS.log.error('[homebridge-ring] - Failed to get credentials')
+        HBS.log.error(e)
+        response.send({ error: e })
+      }
+    }
+  }
+}

--- a/server/api.js
+++ b/server/api.js
@@ -166,7 +166,8 @@ module.exports = class API {
             plugins: new (require("../controllers/plugins"))(),
             accessories: new (require("../controllers/accessories"))(),
             layout: new (require("../controllers/layout"))(),
-            cockpit: new (require("../controllers/cockpit"))()
+            cockpit: new (require("../controllers/cockpit"))(),
+            ringLogin: new (require("../controllers/ring-login"))()
         }
 
         if (client) {

--- a/src/components/plugin-config.vue
+++ b/src/components/plugin-config.vue
@@ -27,7 +27,10 @@
             {{ plugin.description }}
         </p>
         <div v-if="plugin.details.findIndex(p => p.type === 'platform') >= 0">
-            <div v-if="plugin.schema && plugin.schema.platform.schema.properties">
+            <div v-if="plugin.name === 'homebridge-ring' && !value.platforms[platformIndex()].refreshToken">
+                <ring-login :save="save" v-model="value.platforms[platformIndex()]"></ring-login>
+            </div>
+            <div v-else-if="plugin.schema && plugin.schema.platform.schema.properties">
                 <schema-form :schema="plugin.schema.platform.schema.properties || {}" v-model="value.platforms[platformIndex()]" />
             </div>
             <div v-else>
@@ -68,6 +71,7 @@
     import ModalDialog from "@/components/modal-dialog.vue";
     import SchemaForm from "@/components/schema-form.vue";
     import ConfirmDelete from "@/components/confirm-delete.vue";
+    import RingLogin from "@/components/ring-login.vue";
 
     export default {
         name: "plugin-config",
@@ -76,7 +80,8 @@
             "json-editor": JSONEditor,
             "modal-dialog": ModalDialog,
             "schema-form": SchemaForm,
-            "confirm-delete": ConfirmDelete
+            "confirm-delete": ConfirmDelete,
+            "ring-login": RingLogin
         },
 
         props: {

--- a/src/components/ring-login.vue
+++ b/src/components/ring-login.vue
@@ -1,0 +1,132 @@
+<!-------------------------------------------------------------------------------------------------
+ | hoobs-core                                                                                     |
+ | Copyright (C) 2020 HOOBS                                                                       |
+ |                                                                                                |
+ | This program is free software: you can redistribute it and/or modify                           |
+ | it under the terms of the GNU General Public License as published by                           |
+ | the Free Software Foundation, either version 3 of the License, or                              |
+ | (at your option) any later version.                                                            |
+ |                                                                                                |
+ | This program is distributed in the hope that it will be useful,                                |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of                                 |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                                  |
+ | GNU General Public License for more details.                                                   |
+ |                                                                                                |
+ | You should have received a copy of the GNU General Public License                              |
+ | along with this program.  If not, see <http://www.gnu.org/licenses/>.                          |
+ -------------------------------------------------------------------------------------------------->
+
+<template>
+    <div id="ring-login">
+        <div v-if="errors.length > 0" class="errors">
+            <div v-for="(error, index) in errors" :key="index">{{ error }}</div>
+        </div>
+        <div v-if="attemptingLogin">
+            <p>Logging Into Ring...</p>
+            <loading-marquee :height="3" color="--title-text" background="--title-text-dim" />
+        </div>
+        <div v-else-if="codeSentTo">
+            <form autocomplete="false" v-on:submit.prevent="attemptLogin()">
+                <integer-field name="VerificationCode" :description="'Please enter the code sent to ' + codeSentTo"
+                               v-model="verificationCode" :required="true"/>
+                <input type="submit" value="Verify Code" class="button button-primary"
+                       v-bind:disabled="!verificationCode"/>
+            </form>
+        </div>
+        <div v-else>
+            <form autocomplete="false" v-on:submit.prevent="attemptLogin()">
+                <text-field name="Ring Account Email" v-model="email" :required="true"/>
+                <password-field name="Ring Account Password"
+                                description="Your password will not be stored or sent to any third parties apart from ring.com"
+                                v-model="password" :required="true"/>
+                <input type="submit" value="Request Verification Code" class="button button-primary"
+                       v-bind:disabled="!email || !password"/>
+            </form>
+        </div>
+    </div>
+</template>
+
+<script>
+  import TextField from '@/components/text-field.vue'
+  import PasswordField from '@/components/password-field.vue'
+  import IntegerField from '@/components/integer-field.vue'
+  import LoadingMarquee from '@/components/loading-marquee'
+
+  export default {
+    name: 'ring-login',
+
+    components: {
+      'text-field': TextField,
+      'password-field': PasswordField,
+      'integer-field': IntegerField,
+      'loading-marquee': LoadingMarquee
+    },
+
+    data () {
+      return {
+        email: '',
+        password: '',
+        verificationCode: '',
+        attemptingLogin: false,
+        codeSentTo: '',
+        errors: []
+      }
+    },
+
+    props: {
+      value: Object,
+      save: Function
+    },
+
+    computed: {},
+
+    mounted () {
+      this.email = ''
+      this.password = ''
+      this.verificationCode = ''
+      this.attemptingLogin = false
+      this.codeSentTo = ''
+      this.errors = []
+    },
+
+    methods: {
+      async attemptLogin () {
+        this.errors = []
+        this.attemptingLogin = true
+
+        try {
+          const response = await this.api.post(`/ring-login`, {
+            email: this.email,
+            password: this.password,
+            verificationCode: this.verificationCode
+          })
+
+          if (response.error) {
+            this.errors.push(response.error_description || response.error)
+          } else if (response.refresh_token) {
+            this.value.refreshToken = response.refresh_token
+            this.save()
+            return
+          } else if (response.phone) {
+            this.codeSentTo = response.phone
+          } else {
+            this.errors.push(response)
+          }
+        } catch (e) {
+          this.errors.push('Login failed: ' + e.message)
+          console.error(e)
+        }
+
+        this.attemptingLogin = false
+      }
+    }
+  }
+</script>
+
+<style scoped>
+    #ring-login .errors {
+        padding-bottom: 5px;
+        font-size: 14px;
+        color: var(--error-text);
+    }
+</style>


### PR DESCRIPTION
This adds a UI for users to log in with the Ring email/password/2fa code.  When they visit the plugin configuration for Ring, it will automatically switch to the login view if there is no `refreshToken` in their ring platform config.  Once they finish the login flow, their config is saved and the normal schema config editor is shown.